### PR TITLE
Add to support desktop

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,0 +1,4 @@
+{
+  "flutterSdkVersion": "stable",
+  "flavors": {}
+}

--- a/.github/workflows/analyze_test.yml
+++ b/.github/workflows/analyze_test.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   analyze:
+    name: Analyze
     runs-on: ubuntu-latest
 
     steps:
@@ -35,6 +36,7 @@ jobs:
           fi
 
   test:
+    name: Test
     runs-on: ubuntu-latest
 
     steps:
@@ -48,10 +50,17 @@ jobs:
         with:
           channel: stable
 
+      - name: Cache Pub 💾
+        uses: actions/cache@v2
+        with:
+          path: /opt/hostedtoolcache/flutter/*-stable/x64/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
       - name: Run tests 🧪
         run: |
           flutter pub get
-          flutter packages pub run build_runner build --delete-conflicting-outputs
           flutter test --coverage
 
       - name: Upload coverage report 📡

--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ doc/api/
 **/doc/api/
 .flutter-plugins
 .flutter-plugins-dependencies
-.fvm/
+.fvm/flutter_sdk
 .pub-cache/
 .pub/
 coverage/

--- a/lib/src/google_api_headers.dart
+++ b/lib/src/google_api_headers.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:google_api_headers/src/my_platform.dart';
-import 'package:package_info/package_info.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 /// GoogleApiHeaders provide a method for getting the headers required for
 /// calling Google APIs with a restricted key.
@@ -30,13 +30,13 @@ class GoogleApiHeaders {
   /// based on the platform (iOS or Android). For web,
   /// an empty header will be returned.
   Future<Map<String, String>> getHeaders() async {
-    if (_headers.isEmpty && !kIsWeb) {
+    if (_headers.isEmpty && !kIsWeb && !platform.isDesktop) {
       final packageInfo = await PackageInfo.fromPlatform();
-      if (platform.isIos()) {
+      if (platform.isIos) {
         _headers = {
           "X-Ios-Bundle-Identifier": packageInfo.packageName,
         };
-      } else if (platform.isAndroid()) {
+      } else if (platform.isAndroid) {
         try {
           final sha1 = await _channel.invokeMethod(
             'getSigningCertSha1',

--- a/lib/src/my_platform.dart
+++ b/lib/src/my_platform.dart
@@ -2,11 +2,14 @@ import 'dart:io';
 
 /// Abstract class for platform implementations.
 abstract class MyPlatform {
-  /// Returns whether the platform is Android or not.
-  bool isAndroid();
+  /// Returns if the platform is Android.
+  bool get isAndroid;
 
-  /// Returns whether the platform is iOS or not.
-  bool isIos();
+  /// Returns if the platform is iOS.
+  bool get isIos;
+
+  /// Returns if the platform is desktop.
+  bool get isDesktop;
 }
 
 /// MyPlatformImp implements the methods of whether the platform is
@@ -16,8 +19,13 @@ class MyPlatformImp implements MyPlatform {
   const MyPlatformImp();
 
   @override
-  bool isAndroid() => Platform.isAndroid;
+  bool get isAndroid => Platform.isAndroid;
 
   @override
-  bool isIos() => Platform.isIOS;
+  bool get isIos => Platform.isIOS;
+
+  @override
+  bool get isDesktop {
+    return Platform.isMacOS || Platform.isWindows || Platform.isLinux;
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,13 +11,13 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  package_info: ">=2.0.0 <2.1.0"
+  package_info_plus: ^1.0.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   build_runner: ^2.0.0
-  mockito: ^5.0.0
+  mocktail: ^0.1.4
   pedantic: ^1.11.0
 
 flutter:
@@ -29,4 +29,10 @@ flutter:
       ios:
         default_package: google_api_headers
       web:
+        default_package: google_api_headers
+      macos:
+        default_package: google_api_headers
+      windows:
+        default_package: google_api_headers
+      linux:
         default_package: google_api_headers

--- a/test/my_platform_test.dart
+++ b/test/my_platform_test.dart
@@ -4,10 +4,14 @@ import 'package:google_api_headers/google_api_headers.dart';
 void main() {
   final platform = MyPlatformImp();
   test('testIsIos', () {
-    expect(platform.isIos(), false);
+    expect(platform.isIos, false);
   });
 
   test('testIsAndroid', () {
-    expect(platform.isAndroid(), false);
+    expect(platform.isAndroid, false);
+  });
+
+  test('testIsDesktop', () {
+    expect(platform.isDesktop, true);
   });
 }


### PR DESCRIPTION
- Add to support desktop where plugin will return empty headers if it's used on desktops
- Update from `package_info` to `package_info_plus`
- Tidy up tests