### PR TITLE
revert: "fix(deps): update dependency package_info_plus to v5"

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  package_info_plus: ^5.0.0
+  package_info_plus: ^4.0.0
 
 dev_dependencies:
   build_runner: 2.4.6


### PR DESCRIPTION
Reverts zeshuaro/google_api_headers#164

Due to https://github.com/fluttercommunity/plus_plugins/issues/2251