### PR TITLE
fix: Remove default_package: google_api_headers

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,13 +25,3 @@ flutter:
       android:
         package: io.github.zeshuaro.google_api_headers
         pluginClass: GoogleApiHeadersPlugin
-      ios:
-        default_package: google_api_headers
-      web:
-        default_package: google_api_headers
-      macos:
-        default_package: google_api_headers
-      windows:
-        default_package: google_api_headers
-      linux:
-        default_package: google_api_headers


### PR DESCRIPTION
Fixes #461 

Latest Flutter version from beta channel (v2.25.0) issues a warning for those items

<img width="1111" alt="Screenshot 2024-08-25 at 21 16 52" src="https://github.com/user-attachments/assets/4f78c239-b590-465e-a1df-61c0dfc8afed">
