### PR TITLE
fix: Null Error fix

### DIFF
--- a/android/src/main/kotlin/io/github/zeshuaro/google_api_headers/GoogleApiHeadersPlugin.kt
+++ b/android/src/main/kotlin/io/github/zeshuaro/google_api_headers/GoogleApiHeadersPlugin.kt
@@ -38,21 +38,37 @@ class GoogleApiHeadersPlugin : MethodCallHandler, FlutterPlugin {
                 val packageManager = context!!.packageManager
                 val args = call.arguments<String>()!!
                 if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
-                    packageManager.getPackageInfo(
+                    val packageInfo = packageManager.getPackageInfo(
                         args,
                         PackageManager.GET_SIGNING_CERTIFICATES
-                    ).signingInfo.apkContentsSigners.forEach { signature ->
-                        parseSignature(
-                            signature,
-                            result
-                        )
+                    )
+                    val signingInfo = packageInfo.signingInfo
+                    if (signingInfo != null) {
+                        val signers = signingInfo.apkContentsSigners
+                        if (signers != null) {
+                            signers.forEach { signature ->
+                                parseSignature(signature, result)
+                            }
+                        } else {
+                            result.error("ERROR", "No signing certificates found", null)
+                        }
+                    } else {
+                        result.error("ERROR", "Unable to get signing info", null)
                     }
                 } else {
                     @Suppress("DEPRECATION")
-                    packageManager.getPackageInfo(
+                    val packageInfo = packageManager.getPackageInfo(
                         args,
                         PackageManager.GET_SIGNATURES
-                    ).signatures.forEach { signature -> parseSignature(signature, result) }
+                    )
+                    val signatures = packageInfo.signatures
+                    if (signatures != null) {
+                        signatures.forEach { signature -> 
+                            parseSignature(signature, result)
+                        }
+                    } else {
+                        result.error("ERROR", "No signatures found", null)
+                    }
                 }
 
             } catch (e: Exception) {


### PR DESCRIPTION
Following errors fixed:

 file:///Users/jasminder/.pub-cache/hosted/pub.dev/google_api_headers-4.4.4/android/src/main/kotlin/io/github/zeshuaro/google_api_headers/GoogleApiHeadersPlugin.kt:44:34 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type SigningInfo?
e: file:///Users/jasminder/.pub-cache/hosted/pub.dev/google_api_headers-4.4.4/android/src/main/kotlin/io/github/zeshuaro/google_api_headers/GoogleApiHeadersPlugin.kt:55:33 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type Array<(out) Signature!>?

flutter doctor
Doctor summary (to see all details, run flutter doctor -v):
[✓] Flutter (Channel stable, 3.29.3, on macOS 15.3.1 24D70 darwin-arm64, locale en-IN)
[✓] Android toolchain - develop for Android devices (Android SDK version 35.0.1)
[✓] Xcode - develop for iOS and macOS (Xcode 16.3)
[✓] Chrome - develop for the web
[✓] Android Studio (version 2024.3)